### PR TITLE
Fix libdir detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ PKG_CHECK_MODULES([OPENSSL], [openssl])
 PKG_CHECK_MODULES([LUA], [lua])
 
 # lua libdir
-LUALIBDIR="`$PKGCONFIG --variable=libdir lua`"
+LUALIBDIR="`$PKGCONFIG --variable=INSTALL_CMOD lua`"
 
 # dest of headers
 CRYPTOINC="${includedir}/${PACKAGE_NAME}"


### PR DESCRIPTION
This patch fix installation issue at least on Debian and Ubuntu.

In lua5.1.pc delivered in debian package, variable to be used to install lua
binary module is INSTALL_CMOD:

 # The following are intended to be used via "pkg-config --variable".
 # Install paths for Lua modules.  For example, if a package wants to install
 # Lua source modules to the /usr/local tree, call pkg-config with
 # "--define-variable=prefix=/usr/local" and "--variable=INSTALL_LMOD".
 INSTALL_LMOD=${prefix}/share/lua/${major_version}
 INSTALL_CMOD=${prefix}/lib/${deb_host_multiarch}/lua/${major_version}